### PR TITLE
Build with CMake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ Debug/
 Release/
 x64/
 *.vcxproj.user
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,165 @@
+cmake_minimum_required(VERSION 3.12)
+
+# Disable in-source builds to prevent source tree corruption.
+if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
+    message(FATAL_ERROR "FATAL: In-source builds are not allowed.
+    You should create a separate directory for build files.")
+endif()
+
+project(
+    libserialport
+	VERSION 0.1.1
+	DESCRIPTION "cross-platform library for accessing serial ports."
+	HOMEPAGE_URL "https://sigrok.org/wiki/libserialport"
+	LANGUAGES C
+)
+
+# Custom modules
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+set(PACKAGE_NAME              ${PROJECT_NAME})
+set(PACKAGE_BUGREPORT         "martin-libserialport@earth.li")
+set(RESOURCE_FILE_LICENSE     "${CMAKE_CURRENT_SOURCE_DIR}/COPYING")
+set(PACKAGE_VERSION_MAJOR     ${PROJECT_VERSION_MAJOR})
+set(PACKAGE_VERSION_MINOR     ${PROJECT_VERSION_MINOR})
+set(PACKAGE_VERSION_PATCH     ${PROJECT_VERSION_PATCH})
+
+set(LIB_VERSION_AGE         1)
+set(LIB_VERSION_CURRENT     1)
+set(LIB_VERSION_REVISION    0)
+set(LIB_VERSION_STRING
+    "${LIB_VERSION_CURRENT}:${LIB_VERSION_REVISION}:${LIB_VERSION_AGE}")
+
+# Include check modules
+include(CheckSys)
+include(CheckTypes)
+include(CheckIncludes)
+include(CheckFunctions)
+include(CheckAttributes)
+include(CheckDeclarations)
+
+configure_file(
+    "${CMAKE_MODULE_PATH}/config.h.in"
+    "${CMAKE_CURRENT_SOURCE_DIR}/config.h"
+    @ONLY
+)
+
+include(GNUInstallDirs)
+
+add_definitions(-D_GNU_SOURCE)
+add_definitions(-DLIBSERIALPORT_ATBUILD)
+add_compile_options(-Wall -Wextra -pedantic -Wno-unused-parameter)
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+
+set(
+    LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/lib
+)
+
+set(
+    LSP_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/serialport.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/timing.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/libserialport_internal.h
+)
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+    set(
+        LSP_SOURCES ${LSP_SOURCES}
+        ${CMAKE_CURRENT_SOURCE_DIR}/linux.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/linux_termios.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/linux_termios.h
+    )
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    set(
+        LSP_SOURCES ${LSP_SOURCES}
+        ${CMAKE_CURRENT_SOURCE_DIR}/windows.c
+    )
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(
+        LSP_SOURCES ${LSP_SOURCES}
+        ${CMAKE_CURRENT_SOURCE_DIR}/macosx.c
+    )
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+    set(
+        LSP_SOURCES ${LSP_SOURCES}
+        ${CMAKE_CURRENT_SOURCE_DIR}/freebsd.c
+    )
+else()
+    message(
+        FATAL_ERROR
+        "
+        No support for ${CMAKE_SYSTEM_NAME} operating system.
+        Only available for [Linux, Darwin, FreeBSD, Windows].
+        "
+    )
+endif()
+
+string(REPLACE "lib" "" LIBRARY_NAME ${PROJECT_NAME})
+add_library(${LIBRARY_NAME} SHARED ${LSP_SOURCES})
+add_library(${LIBRARY_NAME}_static STATIC ${LSP_SOURCES})
+
+if (UNIX)
+    set_target_properties(
+        ${LIBRARY_NAME}_static
+        PROPERTIES OUTPUT_NAME ${PROJECT_NAME}
+    )
+
+    configure_file(
+        ${CMAKE_MODULE_PATH}/libserialport.pc.in
+        ${CMAKE_CURRENT_BINARY_DIR}/libserialport.pc
+        @ONLY
+    )
+
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/libserialport.pc
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/pkgconfig
+    )
+endif()
+
+set_target_properties(
+    ${LIBRARY_NAME}
+    PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+)
+
+set_target_properties(
+    ${LIBRARY_NAME}_static
+    PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+)
+
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    target_link_libraries(${LIBRARY_NAME} setupapi)
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    find_library(IOKit IOKit)
+    find_library(CoreFoundation CoreFoundation)
+    target_link_libraries(${LIBRARY_NAME} ${IOKit} ${CoreFoundation})
+endif()
+
+install(
+    TARGETS ${LIBRARY_NAME}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(
+    FILES ${CMAKE_CURRENT_SOURCE_DIR}/libserialport.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+if(NOT TARGET uninstall)
+    configure_file(
+        ${CMAKE_MODULE_PATH}/cmake_uninstall.cmake.in
+        ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
+        IMMEDIATE @ONLY
+    )
+
+    add_custom_target(
+        uninstall
+        COMMAND ${CMAKE_COMMAND} -P ${CMAKE_BINARY_DIR}/cmake_uninstall.cmake
+    )
+endif()
+
+add_subdirectory(examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,12 @@ set(
     LSP_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/serialport.c
     ${CMAKE_CURRENT_SOURCE_DIR}/timing.c
+)
+
+set(
+    LSP_HEADER
     ${CMAKE_CURRENT_SOURCE_DIR}/libserialport_internal.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/libserialport.h
 )
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
@@ -68,6 +73,10 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
         LSP_SOURCES ${LSP_SOURCES}
         ${CMAKE_CURRENT_SOURCE_DIR}/linux.c
         ${CMAKE_CURRENT_SOURCE_DIR}/linux_termios.c
+    )
+
+    set(
+        LSP_HEADER ${LSP_HEADER}
         ${CMAKE_CURRENT_SOURCE_DIR}/linux_termios.h
     )
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
@@ -96,13 +105,31 @@ else()
 endif()
 
 string(REPLACE "lib" "" LIBRARY_NAME ${PROJECT_NAME})
-add_library(${LIBRARY_NAME} SHARED ${LSP_SOURCES})
-add_library(${LIBRARY_NAME}_static STATIC ${LSP_SOURCES})
+
+add_library(
+    ${LIBRARY_NAME} SHARED
+    ${LSP_SOURCES} ${LSP_HEADER}
+)
+
+add_library(
+    ${LIBRARY_NAME}_static STATIC
+    ${LSP_SOURCES} ${LSP_HEADER}
+)
+
+target_include_directories(
+    ${LIBRARY_NAME}
+    INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_include_directories(
+    ${LIBRARY_NAME}_static
+    INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}
+)
 
 if (UNIX)
     set_target_properties(
         ${LIBRARY_NAME}_static
-        PROPERTIES OUTPUT_NAME ${PROJECT_NAME}
+        PROPERTIES OUTPUT_NAME ${LIBRARY_NAME}
     )
 
     configure_file(
@@ -133,15 +160,24 @@ set_target_properties(
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     target_link_libraries(${LIBRARY_NAME} setupapi)
+    target_link_libraries(${LIBRARY_NAME}_static setupapi)
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     find_library(IOKit IOKit)
     find_library(CoreFoundation CoreFoundation)
     target_link_libraries(${LIBRARY_NAME} ${IOKit} ${CoreFoundation})
+    target_link_libraries(${LIBRARY_NAME}_static ${IOKit} ${CoreFoundation})
 endif()
 
 install(
     TARGETS ${LIBRARY_NAME}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(
+    TARGETS ${LIBRARY_NAME}_static
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
 
 install(

--- a/cmake/CheckAttributes.cmake
+++ b/cmake/CheckAttributes.cmake
@@ -1,0 +1,34 @@
+include(CheckCSourceCompiles)
+
+macro(check_attribute_exists attr var)
+    set(CMAKE_C_FLAGS_BKP ${CMAKE_C_FLAGS})
+    if(MSVC)
+        set(CMAKE_C_FLAGS "-WX")
+    else()
+        set(CMAKE_C_FLAGS "-Werror")
+    endif()
+    check_c_source_compiles(
+        "
+        ${attr}
+        void foo(void) {}
+        int main(void) {return 0;}
+        "
+        ${var}
+    )
+    set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS_BKP})
+endmacro()
+
+check_attribute_exists(
+    "__attribute__((visibility(\"hidden\")))" HAVE_ATTRIBUTE
+)
+
+check_attribute_exists(
+    "__declspec(dllexport)" HAVE_DECLSPEC
+)
+
+if(${HAVE_ATTRIBUTE})
+    set(SP_API "__attribute__((visibility(\"default\")))")
+    set(SP_PRIV "__attribute__((visibility(\"hidden\")))")
+elseif(HAVE_DECLSPEC AND ${BUILD_SHARED_LIBS})
+    set(SP_API "__declspec(dllexport)")
+endif()

--- a/cmake/CheckDeclarations.cmake
+++ b/cmake/CheckDeclarations.cmake
@@ -1,0 +1,3 @@
+include(CheckSymbolExists)
+
+check_symbol_exists("BOTHER" "linux/termios.h" HAVE_DECL_BOTHER)

--- a/cmake/CheckFunctions.cmake
+++ b/cmake/CheckFunctions.cmake
@@ -1,0 +1,4 @@
+include(CheckFunctionExists)
+
+check_function_exists("clock_gettime" HAVE_CLOCK_GETTIME)
+check_function_exists("realpath" HAVE_REALPATH)

--- a/cmake/CheckIncludes.cmake
+++ b/cmake/CheckIncludes.cmake
@@ -1,0 +1,17 @@
+include(CheckIncludeFiles)
+
+check_include_files("dlfcn.h"       HAVE_DLFCN_H        )
+check_include_files("inttypes.h"    HAVE_INTTYPES_H     )
+check_include_files("memory.h"      HAVE_MEMORY_H       )
+check_include_files("stdint.h"      HAVE_STDINT_H       )
+check_include_files("stdlib.h"      HAVE_STDLIB_H       )
+check_include_files("strings.h"     HAVE_STRINGS_H      )
+check_include_files("string.h"      HAVE_STRING_H       )
+check_include_files("sys/stat.h"    HAVE_SYS_STAT_H     )
+check_include_files("sys/types.h"   HAVE_SYS_TYPES_H    )
+check_include_files("unistd.h"      HAVE_UNISTD_H       )
+check_include_files("stddef.h"      HAVE_STDDEF_H       )
+
+if (HAVE_STDLIB_H AND HAVE_STDDEF_H)
+    set(STDC_HEADERS true) # is needed?
+endif()

--- a/cmake/CheckSys.cmake
+++ b/cmake/CheckSys.cmake
@@ -1,0 +1,4 @@
+if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Linux|Darwin|Windows|FreeBSD")
+    set(NO_ENUMERATION true)
+    set(NO_PORT_METADATA true)
+endif()

--- a/cmake/CheckTypes.cmake
+++ b/cmake/CheckTypes.cmake
@@ -1,0 +1,63 @@
+include(CheckCSourceCompiles)
+
+macro(check_type_exists type header var)
+    check_c_source_compiles(
+        "
+        #include <${header}>
+        void foo(${type} test);
+        int main(void) {return 0;}
+        "
+        ${var}
+    )
+endmacro()
+
+macro(check_type_member_exists type member header var)
+    check_c_source_compiles(
+        "
+        #include <${header}>
+        int main(void) {((${type} *)0)->${member}; return 0; }
+        "
+        ${var}
+    )
+endmacro()
+
+function(setnot var res)
+    if(${var})
+        set(${res} false PARENT_SCOPE)
+    else()
+        set(${res} true  PARENT_SCOPE)
+    endif()
+endfunction()
+
+check_type_exists(
+    "size_t" "sys/types.h" HAVE_SIZE_T
+)
+setnot(HAVE_SIZE_T size_t)
+
+check_type_exists(
+    "struct termiox" "linux/termios.h" HAVE_STRUCT_TERMIOX
+)
+
+check_type_exists(
+    "struct termios2" "linux/termios.h" HAVE_STRUCT_TERMIOS2
+)
+
+check_type_exists(
+    "struct serial_struct" "linux/serial.h" HAVE_STRUCT_SERIAL_STRUCT
+)
+
+check_type_member_exists(
+    "struct termios" "c_ispeed" "linux/termios.h" HAVE_STRUCT_TERMIOS_C_ISPEED
+)
+
+check_type_member_exists(
+    "struct termios" "c_ospeed" "linux/termios.h" HAVE_STRUCT_TERMIOS_C_OSPEED
+)
+
+check_type_member_exists(
+    "struct termios2" "c_ispeed" "linux/termios.h" HAVE_STRUCT_TERMIOS2_C_ISPEED
+)
+
+check_type_member_exists(
+    "struct termios2" "c_ospeed" "linux/termios.h" HAVE_STRUCT_TERMIOS2_C_OSPEED
+)

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -1,0 +1,21 @@
+if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+endif()
+
+file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif()
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif()
+endforeach()

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -1,0 +1,143 @@
+/* config.h.  Generated from cmake/config.h.in by cmake.  */
+
+/* clock_gettime is available. */
+#cmakedefine HAVE_CLOCK_GETTIME 1
+
+/* Define to 1 if you have the declaration of `BOTHER', and to 0 if you don't.
+   */
+#cmakedefine01 HAVE_DECL_BOTHER
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#cmakedefine HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#cmakedefine HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the <memory.h> header file. */
+#cmakedefine HAVE_MEMORY_H 1
+
+/* realpath is available. */
+#cmakedefine HAVE_REALPATH 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#cmakedefine HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#cmakedefine HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#cmakedefine HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#cmakedefine HAVE_STRING_H 1
+
+/* Define to 1 if the system has the type `struct serial_struct'. */
+#cmakedefine HAVE_STRUCT_SERIAL_STRUCT 1
+
+/* Define to 1 if the system has the type `struct termios2'. */
+#cmakedefine HAVE_STRUCT_TERMIOS2 1
+
+/* Define to 1 if `c_ispeed' is a member of `struct termios2'. */
+#cmakedefine HAVE_STRUCT_TERMIOS2_C_ISPEED 1
+
+/* Define to 1 if `c_ospeed' is a member of `struct termios2'. */
+#cmakedefine HAVE_STRUCT_TERMIOS2_C_OSPEED 1
+
+/* Define to 1 if `c_ispeed' is a member of `struct termios'. */
+#cmakedefine HAVE_STRUCT_TERMIOS_C_ISPEED 1
+
+/* Define to 1 if `c_ospeed' is a member of `struct termios'. */
+#cmakedefine HAVE_STRUCT_TERMIOS_C_OSPEED 1
+
+/* Define to 1 if the system has the type `struct termiox'. */
+#cmakedefine HAVE_STRUCT_TERMIOX 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#cmakedefine HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#cmakedefine HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#cmakedefine HAVE_UNISTD_H 1
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Enumeration is unsupported. */
+#cmakedefine NO_ENUMERATION 1
+
+/* Port metadata is unavailable. */
+#cmakedefine NO_PORT_METADATA 1
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "@PACKAGE_BUGREPORT@"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "@PACKAGE_NAME@"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "@PACKAGE_INSTALL_DIRECTORY@"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "@PACKAGE_NAME@"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL "@CMAKE_PROJECT_HOMEPAGE_URL@"
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "@PACKAGE_VERSION@"
+
+/* Macro preceding public API functions */
+#define SP_API @SP_API@
+
+/* . */
+#define SP_LIB_VERSION_AGE @LIB_VERSION_AGE@
+
+/* . */
+#define SP_LIB_VERSION_CURRENT @LIB_VERSION_CURRENT@
+
+/* . */
+#define SP_LIB_VERSION_REVISION @LIB_VERSION_REVISION@
+
+/* . */
+#define SP_LIB_VERSION_STRING "@LIB_VERSION_STRING@"
+
+/* . */
+#define SP_PACKAGE_VERSION_MAJOR @PROJECT_VERSION_MAJOR@
+
+/* . */
+#define SP_PACKAGE_VERSION_MICRO @PROJECT_VERSION_PATCH@
+
+/* . */
+#define SP_PACKAGE_VERSION_MINOR @PROJECT_VERSION_MINOR@
+
+/* . */
+#define SP_PACKAGE_VERSION_STRING "@PROJECT_VERSION@"
+
+/* Macro preceding private functions */
+#define SP_PRIV @SP_PRIV@
+
+/* Define to 1 if you have the ANSI C header files. */
+#cmakedefine STDC_HEADERS 1
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+#cmakedefine _FILE_OFFSET_BITS
+
+/* Define for large files, on AIX-style hosts. */
+#cmakedefine _LARGE_FILES
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+#cmakedefine size_t unsigned int
+
+#if HAVE_STRUCT_TERMIOS_C_ISPEED && HAVE_STRUCT_TERMIOS_C_OSPEED
+# define HAVE_TERMIOS_SPEED 1
+#endif
+#if HAVE_STRUCT_TERMIOS2_C_ISPEED && HAVE_STRUCT_TERMIOS2_C_OSPEED
+# define HAVE_TERMIOS2_SPEED 1
+#endif

--- a/cmake/libserialport.pc.in
+++ b/cmake/libserialport.pc.in
@@ -1,0 +1,14 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix="${prefix}/@CMAKE_INSTALL_BINDIR@"
+libdir="${prefix}/@CMAKE_INSTALL_LIBDIR@"
+includedir="${prefix}/@CMAKE_INSTALL_INCLUDEDIR@"
+
+Name: @PROJECT_NAME@
+Description: @PROJECT_DESCRIPTION@
+URL: @PROJECT_HOMEPAGE_URL@
+Version: @PROJECT_VERSION@
+
+Requires: @PROJECT_PC_REQUIRES@
+
+Libs: -L${libdir} -l@LIBRARY_NAME@ @PRIVATE_LIBS@
+Cflags: -I${includedir}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,14 @@
+
+remove_definitions(-DLIBSERIALPORT_ATBUILD)
+
+file(GLOB examples_src "*.c")
+foreach(example_path ${examples_src})
+    get_filename_component(srcname ${example_path} NAME)
+    get_filename_component(execname ${example_path} NAME_WE)
+
+    add_executable(${execname} ${srcname})
+    set_target_properties(${execname} PROPERTIES COMPILE_OPTIONS "-Wall")
+
+    target_link_libraries(${execname} ${LIBRARY_NAME})
+    target_include_directories(${execname} PUBLIC "${PROJECT_BINARY_DIR}")
+endforeach()


### PR DESCRIPTION
Hi,

In this branch I added the files needed to build with CMake.
It builds both static and dynamic libserialport.

Source tree:
- CMakeLists.txt
- cmake/Check* 
    implements the necessary tests similar to autoconf. Are they all necessary?
- cmake/cmake_uninstall.cmake.in
    for uninstallation
- cmake/config.h.in 
    CMake-style configuration
- cmake/libserialport.pc.in 
    package configuration
- examples/CMakeLists.txt
    builds the examples

I have tested the bulid on the following platforms:
- Darwin Kernel Version 19.3.0 (MacOS)
- Linux 4.19.76

If changes are needed I can make them.
So, review and contact me.

Note: if this work is not necessary for any reason please tell me.

Thanks