### PR TITLE
Return proper type when sp_get_port_transport() fails

### DIFF
--- a/serialport.c
+++ b/serialport.c
@@ -155,10 +155,7 @@ SP_API enum sp_transport sp_get_port_transport(const struct sp_port *port)
 {
 	TRACE("%p", port);
 
-	if (!port)
-		RETURN_ERROR(SP_ERR_ARG, "Null port");
-
-	RETURN_INT(port->transport);
+	RETURN_INT(port ? port->transport : SP_TRANSPORT_NATIVE);
 }
 
 SP_API enum sp_return sp_get_port_usb_bus_address(const struct sp_port *port,


### PR DESCRIPTION
The above function must always return an 'enum sp_transport'. So, return
NATIVE if no port is present because its effective meaning within the
API is "you shouldn't call any transport-specific functions for this
port handle".

Fixes bug #1531.

Signed-off-by: Wolfram Sang <wsa@kernel.org>