### PR TITLE
Add support for (socat) pseudo serial ports

### DIFF
--- a/libserialport.h
+++ b/libserialport.h
@@ -450,7 +450,9 @@ enum sp_transport {
 	/** USB serial port adapter. @since 0.1.1 */
 	SP_TRANSPORT_USB,
 	/** Bluetooth serial port adapter. @since 0.1.1 */
-	SP_TRANSPORT_BLUETOOTH
+	SP_TRANSPORT_BLUETOOTH,
+	/** Pseudo serial port. @since 0.1.2 */
+	SP_TRANSPORT_PSEUDO
 };
 
 /**

--- a/serialport.c
+++ b/serialport.c
@@ -47,6 +47,8 @@ static const struct std_baudrate std_baudrates[] = {
 
 void (*sp_debug_handler)(const char *format, ...) = sp_default_debug_handler;
 
+static void init_config(struct sp_port_config *config);
+
 static enum sp_return get_config(struct sp_port *port, struct port_data *data,
 	struct sp_port_config *config);
 
@@ -1652,6 +1654,18 @@ static enum sp_return set_flow(int fd, struct port_data *data)
 }
 #endif /* USE_TERMIOX */
 
+static void init_config(struct sp_port_config *config)
+{
+	config->baudrate = -1;
+	config->bits = -1;
+	config->parity = -1;
+	config->stopbits = -1;
+	config->rts = -1;
+	config->cts = -1;
+	config->dtr = -1;
+	config->dsr = -1;
+}
+
 static enum sp_return get_config(struct sp_port *port, struct port_data *data,
 	struct sp_port_config *config)
 {
@@ -1660,6 +1674,8 @@ static enum sp_return get_config(struct sp_port *port, struct port_data *data,
 	TRACE("%p, %p, %p", port, data, config);
 
 	DEBUG_FMT("Getting configuration for port %s", port->name);
+
+	init_config(config);
 
 #ifdef _WIN32
 	if (!GetCommState(port->hdl, &data->dcb))
@@ -1758,7 +1774,8 @@ static enum sp_return get_config(struct sp_port *port, struct port_data *data,
 	if (tcgetattr(port->fd, &data->term) < 0)
 		RETURN_FAIL("tcgetattr() failed");
 
-	if (ioctl(port->fd, TIOCMGET, &data->controlbits) < 0)
+	if (port->transport != SP_TRANSPORT_PSEUDO && ioctl(port->fd, TIOCMGET,
+			&data->controlbits) < 0)
 		RETURN_FAIL("TIOCMGET ioctl failed");
 
 #ifdef USE_TERMIOX
@@ -1824,7 +1841,7 @@ static enum sp_return get_config(struct sp_port *port, struct port_data *data,
 	if (data->term.c_cflag & CRTSCTS) {
 		config->rts = SP_RTS_FLOW_CONTROL;
 		config->cts = SP_CTS_FLOW_CONTROL;
-	} else {
+	} else if (port->transport != SP_TRANSPORT_PSEUDO) {
 		if (data->termiox_supported && data->rts_flow)
 			config->rts = SP_RTS_FLOW_CONTROL;
 		else
@@ -1836,11 +1853,12 @@ static enum sp_return get_config(struct sp_port *port, struct port_data *data,
 
 	if (data->termiox_supported && data->dtr_flow)
 		config->dtr = SP_DTR_FLOW_CONTROL;
-	else
+	else if (port->transport != SP_TRANSPORT_PSEUDO)
 		config->dtr = (data->controlbits & TIOCM_DTR) ? SP_DTR_ON : SP_DTR_OFF;
 
-	config->dsr = (data->termiox_supported && data->dsr_flow) ?
-		SP_DSR_FLOW_CONTROL : SP_DSR_IGNORE;
+	if (port->transport != SP_TRANSPORT_PSEUDO)
+		config->dsr = (data->termiox_supported && data->dsr_flow) ?
+			SP_DSR_FLOW_CONTROL : SP_DSR_IGNORE;
 
 	if (data->term.c_iflag & IXOFF) {
 		if (data->term.c_iflag & IXON)
@@ -2272,14 +2290,7 @@ SP_API enum sp_return sp_new_config(struct sp_port_config **config_ptr)
 	if (!(config = malloc(sizeof(struct sp_port_config))))
 		RETURN_ERROR(SP_ERR_MEM, "Config malloc failed");
 
-	config->baudrate = -1;
-	config->bits = -1;
-	config->parity = -1;
-	config->stopbits = -1;
-	config->rts = -1;
-	config->cts = -1;
-	config->dtr = -1;
-	config->dsr = -1;
+	init_config(config);
 
 	*config_ptr = config;
 


### PR DESCRIPTION
For example:

    # create a pseudo serial port pair with socat
    $ socat pty,link=$HOME/dev/foo pty,link=$HOME/dev/bar &
    [1] 28005

    # open one side with the await_events example
    $ ./await_events $HOME/dev/foo &
    [2] 28006
    Looking for port $HOME/dev/foo.
    Opening port.
    Setting port to 9600 8N1, no flow control.
    Adding port RX event to event set.
    Waiting up to 5 seconds for RX on any port...

    # open the other side with the send_receive example
    $ ./send_receive $HOME/dev/bar
    Looking for port $HOME/dev/bar.
    Opening port.
    Setting port to 9600 8N1, no flow control.
    Sending 'Hello!' (6 bytes) on port /dev/pts/2.
    Sent 6 bytes successfully.
    Receiving 6 bytes on port /dev/pts/2.
    Port /dev/pts/1: 6 bytes received.  # <== await_events
    Timed out, 0/6 bytes received.
    Received ''.
    [2]+  Done                    ./await_events $HOME/dev/foo

    $ kill 28005 # socat