### PR TITLE
Symlink b

### DIFF
--- a/linux.c
+++ b/linux.c
@@ -40,6 +40,7 @@ SP_PRIV enum sp_return get_port_details(struct sp_port *port)
 	 * Description limited to 127 char, anything longer
 	 * would not be user friendly anyway.
 	 */
+	char name[PATH_MAX + 1];
 	char description[128];
 	int bus, address;
 	unsigned int vid, pid;
@@ -47,12 +48,17 @@ SP_PRIV enum sp_return get_port_details(struct sp_port *port)
 	char baddr[32];
 	const char dir_name[] = "/sys/class/tty/%s/device/%s%s";
 	char sub_dir[32] = "", link_name[PATH_MAX], file_name[PATH_MAX];
-	char *ptr, *dev = port->name + 5;
+	char *ptr, *dev;
 	FILE *file;
 	int i, count;
 	struct stat statbuf;
 
-	if (strncmp(port->name, "/dev/", 5))
+	char *res = realpath(port->name, name);
+	if (!res)
+		RETURN_ERROR(SP_ERR_ARG, "Could not retrieve realpath behind port name");
+	dev = name + 5;
+
+	if (strncmp(name, "/dev/", 5))
 		RETURN_ERROR(SP_ERR_ARG, "Device name not recognized");
 
 	snprintf(link_name, sizeof(link_name), "/sys/class/tty/%s", dev);

--- a/serialport.c
+++ b/serialport.c
@@ -73,20 +73,6 @@ SP_API enum sp_return sp_get_port_by_name(const char *portname, struct sp_port *
 
 	DEBUG_FMT("Building structure for port %s", portname);
 
-#if !defined(_WIN32) && defined(HAVE_REALPATH)
-	/*
-	 * get_port_details() below tries to be too smart and figure out
-	 * some transport properties from the port name which breaks with
-	 * symlinks. Therefore we canonicalize the portname first.
-	 */
-	char pathbuf[PATH_MAX + 1];
-	char *res = realpath(portname, pathbuf);
-	if (!res)
-		RETURN_ERROR(SP_ERR_ARG, "Could not retrieve realpath behind port name");
-
-	portname = pathbuf;
-#endif
-
 	if (!(port = malloc(sizeof(struct sp_port))))
 		RETURN_ERROR(SP_ERR_MEM, "Port structure malloc failed");
 


### PR DESCRIPTION
Would like to add the ability for libserialport to recognize and use symlinks on Linux. This is primarily in support of the Arduino IDE which uses libserialport to enumerate and list serial ports however it seems like it would be beneficial to any libserialport users. Symlinks are created on Linux when udev rules are used to map a specific device or class of devices to a symlink. In order to accommodate this add code to find symlinks base on TTY devices found and then I removed a block of code that ensure a real path was passed to the serial port creator and moved this call in the Linux only portion of the code. Based on some research Mac OSX doesn't seem allow for symlink serial ports and there was a guard on the code already to stop it from running on Windows so that leaves BSD which I am unfamiliar with. I have another version of this feature where I added a realpath element to the sp_port struct however that seems more error prone. I was able to get all of the examples to run with my code modifications.  

The only other note is that there is two commits here the first adds the code to allow the symlinks to be found. The second moves the realpath code to allow the symlink port names to pass through. 

This is my first pull request to an open source project so any feed back is appreciated.