### PR TITLE
Simplify determination of transport

### DIFF
--- a/macosx.c
+++ b/macosx.c
@@ -121,8 +121,8 @@ SP_PRIV enum sp_return get_port_details(struct sp_port *port)
 			DEBUG_FMT("Found matching USB VID:PID %04X:%04X", vid, pid);
 			port->usb_vid = vid;
 			port->usb_pid = pid;
-            port->transport = SP_TRANSPORT_USB;
-        }
+			port->transport = SP_TRANSPORT_USB;
+		}
 		if (cf_vendor)
 			CFRelease(cf_vendor);
 		if (cf_product)


### PR DESCRIPTION
This code change makes so that a port is a considered a USB port if and only if it has a USB Vendor ID / Product ID combo.  The old method was more complicated and was failing for the CP2102 chip.