### PR TITLE
Compile with current version of MinGW64 and add _declspec(dllexport/import)

### DIFF
--- a/libserialport.h
+++ b/libserialport.h
@@ -578,7 +578,7 @@ SP_API enum sp_return sp_copy_port(const struct sp_port *port, struct sp_port **
  *
  * @since 0.1.0
  */
-SP_API void  sp_free_port_list(struct sp_port **ports);
+SP_API void sp_free_port_list(struct sp_port **ports);
 
 /**
  * @}
@@ -629,7 +629,7 @@ SP_API enum sp_return sp_close(struct sp_port *port);
  *
  * @since 0.1.0
  */
-SP_API char* sp_get_port_name(const struct sp_port *port);
+SP_API char *sp_get_port_name(const struct sp_port *port);
 
 /**
  * Get a description for a port, to present to end user.
@@ -642,7 +642,7 @@ SP_API char* sp_get_port_name(const struct sp_port *port);
  *
  * @since 0.1.1
  */
-SP_API char* sp_get_port_description(const struct sp_port *port);
+SP_API char *sp_get_port_description(const struct sp_port *port);
 
 /**
  * Get the transport type used by a port.
@@ -697,7 +697,7 @@ SP_API enum sp_return sp_get_port_usb_vid_pid(const struct sp_port *port, int *u
  *
  * @since 0.1.1
  */
-SP_API char* sp_get_port_usb_manufacturer(const struct sp_port *port);
+SP_API char *sp_get_port_usb_manufacturer(const struct sp_port *port);
 
 /**
  * Get the USB product string of a USB serial adapter port.
@@ -710,7 +710,7 @@ SP_API char* sp_get_port_usb_manufacturer(const struct sp_port *port);
  *
  * @since 0.1.1
  */
-SP_API char* sp_get_port_usb_product(const struct sp_port *port);
+SP_API char *sp_get_port_usb_product(const struct sp_port *port);
 
 /**
  * Get the USB serial number string of a USB serial adapter port.
@@ -723,7 +723,7 @@ SP_API char* sp_get_port_usb_product(const struct sp_port *port);
  *
  * @since 0.1.1
  */
-SP_API char* sp_get_port_usb_serial(const struct sp_port *port);
+SP_API char *sp_get_port_usb_serial(const struct sp_port *port);
 
 /**
  * Get the MAC address of a Bluetooth serial adapter port.
@@ -736,7 +736,7 @@ SP_API char* sp_get_port_usb_serial(const struct sp_port *port);
  *
  * @since 0.1.1
  */
-SP_API char* sp_get_port_bluetooth_address(const struct sp_port *port);
+SP_API char *sp_get_port_bluetooth_address(const struct sp_port *port);
 
 /**
  * Get the operating system handle for a port.
@@ -1649,7 +1649,7 @@ SP_API int sp_last_error_code(void);
  *
  * @since 0.1.0
  */
-SP_API char* sp_last_error_message(void);
+SP_API char *sp_last_error_message(void);
 
 /**
  * Free an error message returned by sp_last_error_message().
@@ -1782,7 +1782,7 @@ SP_API int sp_get_micro_package_version(void);
  *
  * @since 0.1.0
  */
-SP_API const char* sp_get_package_version_string(void);
+SP_API const char *sp_get_package_version_string(void);
 
 /**
  * Get the "current" part of the libserialport library version number.
@@ -1819,7 +1819,7 @@ SP_API int sp_get_age_lib_version(void);
  *
  * @since 0.1.0
  */
-SP_API const char* sp_get_lib_version_string(void);
+SP_API const char *sp_get_lib_version_string(void);
 
 /** @} */
 

--- a/libserialport.h
+++ b/libserialport.h
@@ -280,20 +280,32 @@ extern "C" {
 
 /** @cond */
 #ifdef _MSC_VER
-/* Microsoft Visual C/C++ compiler in use */
-#ifdef LIBSERIALPORT_MSBUILD
-/* Building the library - need to export DLL symbols */
-#define SP_API __declspec(dllexport)
+	/* Microsoft Visual C/C++ compiler in use */
+	#ifdef LIBSERIALPORT_MSBUILD
+		// Building the library - need to export DLL symbols
+		#define SP_API __declspec(dllexport)
+	#else
+		// Using the library - need to import DLL symbols
+		#define SP_API __declspec(dllimport)
+	#endif
+	// #define SP_CALL
+#elif defined(__MINGW32__)
+	// You should define LIBSERIALPORT_MINGW64BUILD *only* when building the DLL.
+	#ifdef LIBSERIALPORT_MINGW64BUILD
+		#define SP_API __declspec(dllexport)
+	#else
+		#define SP_API __declspec(dllimport)
+	#endif
+	// Define calling convention in one place, for convenience.
+	// On MinGW64 "__cdecl" is default value.
+	// #define SP_CALL __cdecl
 #else
-/* Using the library - need to import DLL symbols */
-#define SP_API __declspec(dllimport)
-#endif
-#else
-/* Some other compiler in use */
-#ifndef LIBSERIALPORT_ATBUILD
-/* Not building the library itself - don't need any special prefixes. */
-#define SP_API
-#endif
+	/* Some other compiler in use */
+	#ifndef LIBSERIALPORT_ATBUILD
+		/* Not building the library itself - don't need any special prefixes. */
+		#define SP_API
+	#endif
+	// #define SP_CALL
 #endif
 /** @endcond */
 
@@ -566,7 +578,7 @@ SP_API enum sp_return sp_copy_port(const struct sp_port *port, struct sp_port **
  *
  * @since 0.1.0
  */
-SP_API void sp_free_port_list(struct sp_port **ports);
+SP_API void  sp_free_port_list(struct sp_port **ports);
 
 /**
  * @}
@@ -617,7 +629,7 @@ SP_API enum sp_return sp_close(struct sp_port *port);
  *
  * @since 0.1.0
  */
-SP_API char *sp_get_port_name(const struct sp_port *port);
+SP_API char* sp_get_port_name(const struct sp_port *port);
 
 /**
  * Get a description for a port, to present to end user.
@@ -630,7 +642,7 @@ SP_API char *sp_get_port_name(const struct sp_port *port);
  *
  * @since 0.1.1
  */
-SP_API char *sp_get_port_description(const struct sp_port *port);
+SP_API char* sp_get_port_description(const struct sp_port *port);
 
 /**
  * Get the transport type used by a port.
@@ -685,7 +697,7 @@ SP_API enum sp_return sp_get_port_usb_vid_pid(const struct sp_port *port, int *u
  *
  * @since 0.1.1
  */
-SP_API char *sp_get_port_usb_manufacturer(const struct sp_port *port);
+SP_API char* sp_get_port_usb_manufacturer(const struct sp_port *port);
 
 /**
  * Get the USB product string of a USB serial adapter port.
@@ -698,7 +710,7 @@ SP_API char *sp_get_port_usb_manufacturer(const struct sp_port *port);
  *
  * @since 0.1.1
  */
-SP_API char *sp_get_port_usb_product(const struct sp_port *port);
+SP_API char* sp_get_port_usb_product(const struct sp_port *port);
 
 /**
  * Get the USB serial number string of a USB serial adapter port.
@@ -711,7 +723,7 @@ SP_API char *sp_get_port_usb_product(const struct sp_port *port);
  *
  * @since 0.1.1
  */
-SP_API char *sp_get_port_usb_serial(const struct sp_port *port);
+SP_API char* sp_get_port_usb_serial(const struct sp_port *port);
 
 /**
  * Get the MAC address of a Bluetooth serial adapter port.
@@ -724,7 +736,7 @@ SP_API char *sp_get_port_usb_serial(const struct sp_port *port);
  *
  * @since 0.1.1
  */
-SP_API char *sp_get_port_bluetooth_address(const struct sp_port *port);
+SP_API char* sp_get_port_bluetooth_address(const struct sp_port *port);
 
 /**
  * Get the operating system handle for a port.
@@ -1637,7 +1649,7 @@ SP_API int sp_last_error_code(void);
  *
  * @since 0.1.0
  */
-SP_API char *sp_last_error_message(void);
+SP_API char* sp_last_error_message(void);
 
 /**
  * Free an error message returned by sp_last_error_message().
@@ -1770,7 +1782,7 @@ SP_API int sp_get_micro_package_version(void);
  *
  * @since 0.1.0
  */
-SP_API const char *sp_get_package_version_string(void);
+SP_API const char* sp_get_package_version_string(void);
 
 /**
  * Get the "current" part of the libserialport library version number.
@@ -1807,7 +1819,7 @@ SP_API int sp_get_age_lib_version(void);
  *
  * @since 0.1.0
  */
-SP_API const char *sp_get_lib_version_string(void);
+SP_API const char* sp_get_lib_version_string(void);
 
 /** @} */
 

--- a/libserialport_internal.h
+++ b/libserialport_internal.h
@@ -47,6 +47,16 @@
 #define SP_PRIV
 #endif
 
+#ifdef LIBSERIALPORT_MINGW64BUILD
+/* If building with MinGW64 tools, define necessary things that
+   would otherwise appear in config.h. */
+#define SP_PRIV
+#endif
+
+#ifndef SP_PRIV
+#error "You should define one of LIBSERIALPORT_ATBUILD, LIBSERIALPORT_MSBUILD, LIBSERIALPORT_MINGW64BUILD"
+#endif
+
 #include "libserialport.h"
 
 #include <string.h>

--- a/mingw64.mak
+++ b/mingw64.mak
@@ -1,0 +1,53 @@
+# mingw64.mak: build libserialport.dll using MinGW64-w64
+
+# Program for compiling C programs
+CC = gcc
+
+# Extra flags to give to the C preprocessor
+CPPFLAGS =
+CPPFLAGS += -DLIBSERIALPORT_MINGW64BUILD
+# CPPFLAGS += -DLIBSERIALPORT_MSBUILD
+# CPPFLAGS += -DLIBSERIALPORT_ATBUILD
+# CPPFLAGS += -DHAVE_CONFIG_H
+
+# Extra flags to give to the C compiler.
+CFLAGS =
+CFLAGS += -I. -std=c99
+CFLAGS += -Wall -Wextra -pedantic -Wmissing-prototypes -Wshadow
+CFLAGS += -g -O2
+
+# Extra flags when invoking the linker
+LDFLAGS = -s -shared -Wl,--subsystem,windows
+
+# Library flags or names when invoking the linker
+LDLIBS = -lsetupapi
+
+# Command to remove a file
+RM = rm -f
+
+H_FILES = libserialport_internal.h libserialport.h
+O_FILES = serialport.o timing.o windows.o
+
+all: libserialport.dll
+
+libserialport.dll: $(O_FILES)
+	gcc -o libserialport.dll $(O_FILES) $(LDFLAGS) $(LDLIBS)
+
+serialport.o: serialport.c $(H_FILES)
+	$(CC) -c $(CPPFLAGS) $(CFLAGS) -o $@ $<
+
+timing.o: timing.c $(H_FILES)
+	$(CC) -c $(CPPFLAGS) $(CFLAGS) -o $@ $<
+
+windows.o: windows.c $(H_FILES)
+	$(CC) -c $(CPPFLAGS) $(CFLAGS) -o $@ $<
+
+install:
+	@echo "install is not yet implemented"
+	exit 1
+
+clean:
+	$(RM) libserialport.dll
+	$(RM) *.o
+
+.PHONY: all install clean


### PR DESCRIPTION
1. New Make file "mingw64.mak" to build on current version of MinGW64.
2. added _declspec(dllexport) and _declspec(dllimport) for MinGW64

I had problems with autotools fails on current version of MinGW64 so I wrote a minimalistic Makefile for use with MinGW64 only. It is incomplete that the "install" step is missing, but works for [libserialportCS](https://github.com/pischky/libserialportCS).

From some tutorial about building DLLs with MinGW64 I assume that declarion of the funtctions of the DLL as dllexport is best way. So you should also use dllimport when using the DLL.

This works with [libserialportCS](https://github.com/pischky/libserialportCS). Testing with C or C++ is still missing.