### PR TITLE
Rename deprecated constant kIOMasterPortDefault

### DIFF
--- a/libserialport_internal.h
+++ b/libserialport_internal.h
@@ -93,6 +93,11 @@
 #include <IOKit/serial/ioss.h>
 #include <sys/syslimits.h>
 #include <mach/mach_time.h>
+
+#if (MAC_OS_X_VERSION_MAX_ALLOWED < 120000) /* Before macOS 12 */
+#define kIOMainPortDefault kIOMasterPortDefault
+#endif
+
 #endif
 #ifdef __linux__
 #include <dirent.h>

--- a/macosx.c
+++ b/macosx.c
@@ -42,7 +42,7 @@ SP_PRIV enum sp_return get_port_details(struct sp_port *port)
 	if (!(classes = IOServiceMatching(kIOSerialBSDServiceValue)))
 		RETURN_FAIL("IOServiceMatching() failed");
 
-	if (IOServiceGetMatchingServices(kIOMasterPortDefault, classes,
+	if (IOServiceGetMatchingServices(kIOMainPortDefault, classes,
 	                                 &iter) != KERN_SUCCESS)
 		RETURN_FAIL("IOServiceGetMatchingServices() failed");
 
@@ -56,7 +56,7 @@ SP_PRIV enum sp_return get_port_details(struct sp_port *port)
 		result = CFStringGetCString(cf_property, path, sizeof(path),
 		                            kCFStringEncodingASCII);
 		CFRelease(cf_property);
-		if (!result || strcmp(path, port->name)) {
+		if (!result || strcmp(path, port->name) != 0) {
 			IOObjectRelease(ioport);
 			continue;
 		}
@@ -210,7 +210,7 @@ SP_PRIV enum sp_return list_ports(struct sp_port ***list)
 	}
 
 	DEBUG("Getting matching services");
-	if (IOServiceGetMatchingServices(kIOMasterPortDefault, classes,
+	if (IOServiceGetMatchingServices(kIOMainPortDefault, classes,
 	                                 &iter) != KERN_SUCCESS) {
 		SET_FAIL(ret, "IOServiceGetMatchingServices() failed");
 		goto out_done;


### PR DESCRIPTION
This constant is now deprecated since macOS 12.0 and a new constant named kIOMainPortDefault is provided.

There is a fallback in place that retains compatibility with older macOS versions.

This removes the warnings when compiling the library on modern systems, and makes sure the library will keep working on future versions of the OS.

[https://developer.apple.com/documentation/iokit/kiomasterportdefault](https://developer.apple.com/documentation/iokit/kiomasterportdefault)
[https://developer.apple.com/documentation/iokit/kiomainportdefault](https://developer.apple.com/documentation/iokit/kiomainportdefault)