### PR TITLE
Increase max class string length to 64

### DIFF
--- a/macosx.c
+++ b/macosx.c
@@ -36,7 +36,7 @@ SP_PRIV enum sp_return get_port_details(struct sp_port *port)
 	io_object_t ioport, ioparent;
 	CFTypeRef cf_property, cf_bus, cf_address, cf_vendor, cf_product;
 	Boolean result;
-	char path[PATH_MAX], class[16];
+	char path[PATH_MAX], class[64];
 
 	DEBUG("Getting serial port list");
 	if (!(classes = IOServiceMatching(kIOSerialBSDServiceValue)))


### PR DESCRIPTION
#9 points out that Silabs CP210x chips don't work properly with libserialport. However, the attempted fix is a bit drastic, and only fix the symptom and not the problem.

After a bit of research, I'm pretty sure I've figured out the root cause.

https://github.com/sigrokproject/libserialport/blob/6f9b03e597ea7200eb616a4e410add3dd1690cb1/macosx.c#L39

The `class` string can only hold 16 characters, and this is fine if the assigned string is 16 characters long or less. However, the Silabs `CFSTR("IOProviderClass")` returns "IOUSBHostInterface", which is longer than 16 characters. Other USB to serial chips returns "IOUSBInterface", which is barely less than 16 bytes.

So all this simple PR does is increase the maximum length the `class` string can have.

Here's the output from the port_info example:

Without this PR:

```
$ ./port_info /dev/cu.SLAB_USBtoUART 
Looking for port /dev/cu.SLAB_USBtoUART.
Port name: /dev/cu.SLAB_USBtoUART
Description: CP210x USB to UART Bridge Controller
Type: Native
Freeing port.
```

With this PR:

```
$ ./port_info /dev/cu.SLAB_USBtoUART 
Looking for port /dev/cu.SLAB_USBtoUART.
Port name: /dev/cu.SLAB_USBtoUART
Description: CP210x USB to UART Bridge Controller
Type: USB
Manufacturer: Silicon Labs
Product: CP210x USB to UART Bridge Controller
Serial: 00FEBF3C
VID: 10C4 PID: EA60
Bus: 0 Address: 0
Freeing port.
```

@martinling it would be great if you could review this and hopefully merge it. It would be awesome to have a libserialport version that works with Silabs chips on macOS!