### PR TITLE
Fix segfault if building on macOS 12+ with deployment target <=11

### DIFF
--- a/libserialport_internal.h
+++ b/libserialport_internal.h
@@ -93,9 +93,10 @@
 #include <IOKit/serial/ioss.h>
 #include <sys/syslimits.h>
 #include <mach/mach_time.h>
-#if MAC_OS_X_VERSION_MAX_ALLOWED < 120000 /* Before macOS 12 */
-#define kIOMainPortDefault kIOMasterPortDefault
-#endif
+/* kIOMainPortDefault (kIOMasterPortDefault <= macOS 11) is a
+ * synonym for NULL. Fixes segfault when building on macOS 12+
+ * with an older macOS deployment target. */
+#define kIOMainPortDefault 0
 #endif
 #ifdef __linux__
 #include <dirent.h>


### PR DESCRIPTION
`kIOMasterPortDefault` was replaced by `kIOMainPortDefault` as of macOS 12 and was addressed in #11. However, this causes a segfault if building on macOS 12+ with an older deployment target (for example, GitHub CI/CD runners support macOS 13+ only).

This PR sets `kIOMainPortDefault` to 0:
https://developer.apple.com/documentation/iokit/kiomasterportdefault
"When specifying a primary port to IOKit functions, the NULL argument indicates "use the default". This is a synonym for NULL, if you'd rather use a named constant."

libusb also handles it this way:
https://github.com/libusb/libusb/blob/dcd30cec9a633fb59a619f5bf5f5582d794c8dff/libusb/os/darwin_usb.c#L52
```
/* Both kIOMasterPortDefault or kIOMainPortDefault are synonyms for 0. */
static const mach_port_t darwin_default_master_port = 0;
```

Tested by building SmuView on macOS 13 with a deployment target of 10.13, verified the segfault is fixed when running on a 10.13 system.